### PR TITLE
Added ability to force reveal side in xblock markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ required) that specify the position of the hotspot on the background
 image, `item-id` which can be set to a unique string used to
 identify the hotspot in the emitted events and optional `side` attribute 
 that allows to override hotspot's popup position. If `side` attribute is 
-missing or set to anything except `left`and `right`) autmatic positioning
+missing or set to anything except `left` and `right` automatic positioning
 is used.
 
 Each `<hotspot>` element must contain the `<feedback>` child

--- a/README.md
+++ b/README.md
@@ -91,8 +91,11 @@ background image and the content of the tooltips.
 
 The supported attributes of `<hotspot>` elements are `x` and `y` (both
 required) that specify the position of the hotspot on the background
-image, and `item-id` which can be set to a unique string used to
-identify the hotspot in the emitted events.
+image, `item-id` which can be set to a unique string used to
+identify the hotspot in the emitted events and optional `side` attribute 
+that allows to override hotspot's popup position. If `side` attribute is 
+missing or set to anything except `left`and `right`) autmatic positioning
+is used.
 
 Each `<hotspot>` element must contain the `<feedback>` child
 element. The `<feedback>` element supports `width`, `height` and `max-height`

--- a/image_explorer/image_explorer.py
+++ b/image_explorer/image_explorer.py
@@ -249,6 +249,8 @@ class ImageExplorerBlock(XBlock): # pylint: disable=no-init
             feedback.max_height = feedback_element.get('max-height')
             feedback.header = self._inner_content(feedback_element.find('header'))
 
+            feedback.side = hotspot_element.get('side', 'auto')
+
             feedback.body = None
             body_element = feedback_element.find('body')
             if body_element is not None:

--- a/image_explorer/public/js/image_explorer.js
+++ b/image_explorer/public/js/image_explorer.js
@@ -10,6 +10,29 @@ function ImageExplorerBlock(runtime, element) {
       });
     }
 
+    function setRevealPosition(target, reveal) {
+      var reveal_side = reveal.data('side');
+      var reveal_width = reveal.outerWidth();
+      var target_position_left = target.position().left;
+      var hotspot_image_width = target.outerWidth();
+
+      var image_width = reveal.parents('.image-explorer-hotspot').siblings('.image-explorer-background').outerWidth();
+
+      if (reveal_side !== 'left' && reveal_side !== 'right') {
+          /* do some calculations with regards which side of the hotspot to open the feedback on */
+          if ((target_position_left + reveal_width > image_width) &&
+              (target_position_left - reveal_width - hotspot_image_width > 0)) {
+              reveal_side = 'left';
+          }
+          else {
+              reveal_side = 'right';
+          }
+      }
+      if (reveal_side === 'left') {
+          reveal.css('margin-left', '-' + (reveal_width + hotspot_image_width) + 'px');
+      }
+    }
+
     /* reveal feedback action */
     $(element).find('.image-explorer-hotspot').bind('click', function(eventObj) {
       eventObj.preventDefault();
@@ -17,18 +40,10 @@ function ImageExplorerBlock(runtime, element) {
       $(element).find('.image-explorer-hotspot-reveal').css('display', 'none');
 
       var target = $(eventObj.currentTarget);
-      var target_position_left = target.position().left;
-      var hotspot_image_width = target.outerWidth();
       var reveal = target.find('.image-explorer-hotspot-reveal');
-      var reveal_width = reveal.outerWidth();
-      var parent_wrapper = reveal.parents('.image-explorer-hotspot');
-      var image_element = parent_wrapper.siblings('.image-explorer-background');
-      var image_width = image_element.outerWidth();
 
-      /* do some calculations with regards which side of the hotspot to open the feedback on */
-      if ((target_position_left + reveal_width > image_width) && (target_position_left - reveal_width - hotspot_image_width > 0)) {
-        reveal.css('margin-left', '-' + (reveal_width + hotspot_image_width) + 'px');
-      }
+      setRevealPosition(target, reveal);
+
       reveal.css('display', 'block');
       hotspot_opened_at = new Date().getTime();
       publish_event({

--- a/image_explorer/templates/html/image_explorer.html
+++ b/image_explorer/templates/html/image_explorer.html
@@ -10,7 +10,7 @@
         <img src="{{background.src}}" class="image-explorer-background" />
         {% for hotspot in hotspots %}
         <a class="image-explorer-hotspot" style="position: absolute; top: {{hotspot.y}}px; left: {{hotspot.x}}px; background-image: url('{{sprite_url}}')" data-item-id="{{hotspot.item_id}}" href="#">
-                <div class="image-explorer-hotspot-reveal" {{hotspot.reveal_style}}>
+                <div class="image-explorer-hotspot-reveal" {{hotspot.reveal_style}} data-side="{{ hotspot.feedback.side }}">
                     <div class="image-explorer-close-reveal">&#xf057;</div>
                     <div class="image-explorer-hotspot-content-wrapper">
                         {% if hotspot.feedback.header %}


### PR DESCRIPTION
This patch allows to explicitly set on which side hotspot popup must be shown.

Affected components:  xblock-image-explorer
Affected users: backward compatible with existing course setups. Opt-in to override behavior.

Test instructions (`...` means leave other attributes as is):
1. Import course tarball from https://gist.github.com/e-kolpakov/6a60cd413fe5143dcba7#file-imageexplorerpopupoverride-tar-gz
2. Log in to studio using staff@example.com / edx
3. Navigate to only unit in the course
4. There should be two image-explorer Xblocks: Full auto and Overrides.
5. Full auto should show both popups to the right of the hotspot
6. Overrides should show top hotspot's popup to the right, bottom hotspot's popup to the left.
7. Edit Overrides Xblock so that `<hotspot>` elements have their `side` attributes  changed:
7.1. Set first (hotspotA) `<hotspot ... side='right'>` - should display first hotspot's popup to the right
7.2. Set second (hotspotB) `<hotspot ... side='left'>` - should display second hotspot's popup to the left
7.3. Set first (hotspotA) `<hotspot>` side to anything except `left` or `right` - should display first hotspot's popup in automatic mode (if x and y haven't changed - to the right)
7.4. Set first (hotspotA) `<hotspot x='600' y='20' ... side='right'>` - should display popup to the right, despite crossing image border
7.5. Set first (hotspotA) `<hotspot x='100' y='20' ... side='left'>` - should display popup to the left, despite crossing image border

![xblcok-image-explorer-popup-side-override](https://cloud.githubusercontent.com/assets/3330048/4197676/ab291cf4-37ed-11e4-84a7-36636fc56393.png)
